### PR TITLE
Add FlightLogKind definition, regenerate TS typing

### DIFF
--- a/src/flockwave/spec/definitions.json
+++ b/src/flockwave/spec/definitions.json
@@ -683,7 +683,7 @@
         "type": "number"
       },
       "kind": {
-        "type": "string"
+        "$ref": "#/flightLogKind"
       },
       "body": {
         "type": ["string", "object"]
@@ -697,6 +697,14 @@
     "description": "Identifier of a single flight log",
     "type": "string",
     "minLength": 1
+  },
+
+  "flightLogKind": {
+    "title": "Flight log kind",
+    "description": "Identifier of a flight log kind",
+    "type": "string",
+    "enum": ["text", "ardupilot", "ulog", "flockctrl", "unknown"],
+    "$id": "FlightLogKind"
   },
 
   "flightLogMetadata": {
@@ -714,7 +722,7 @@
         "type": "number"
       },
       "kind": {
-        "type": "string"
+        "$ref": "#/flightLogKind"
       }
     },
     "required": ["id", "kind"]

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -310,6 +310,10 @@ export type DeviceClass =
 export type ChannelOperation = "read" | "write";
 export type LicenseID = string;
 /**
+ * Identifier of a flight log kind
+ */
+export type FlightLogKind = "text" | "ardupilot" | "ulog" | "flockctrl" | "unknown";
+/**
  * The type of the preset (built-in, created automatically or added by the user)
  */
 export type RTKPresetType = "builtin" | "dynamic" | "user";
@@ -1493,7 +1497,7 @@ export interface FlightLog {
   id: FlightLogID;
   timestamp?: number;
   size?: number;
-  kind: string;
+  kind: FlightLogKind;
   body:
     | string
     | {
@@ -1519,7 +1523,7 @@ export interface FlightLogMetadata {
   id: FlightLogID;
   timestamp?: number;
   size?: number;
-  kind: string;
+  kind: FlightLogKind;
   [k: string]: unknown;
 }
 export interface Response_OBJCMD {


### PR DESCRIPTION
I'm trying to sync the `FlightLog` types in flockwave-spec and Live. `FlightLogKind` was one of the issues, the PR fixes it.

The other issue is the `body` attribute, which is a `string` in Live, but it can also be an object according to flockwave-spec. @ntamas Is object really acceptable for the body? If it is, I need to handle that in Live, otherwise I'll make the necessary changes here.